### PR TITLE
Integrates Roundup Action for CI

### DIFF
--- a/.github/workflows/stable-cicd.yaml
+++ b/.github/workflows/stable-cicd.yaml
@@ -1,0 +1,65 @@
+# 🏃‍♀️ Continuous Integration and Delivery: Stable
+# ===============================================
+#
+# Note: for this workflow to succeed, the following secrets must be installed
+# in the repository:
+#
+# ``ADMIN_GITHUB_TOKEN``
+#     A personal access token of a user with collaborator or better access to
+#     the project repository.
+# ``NPMJS_COM_TOKEN`` — token for npmjs.com. To create such a token, visit
+#     npmjs.com, log in, and go to your profile menu → Access Tokens →
+#     Generate new token → Granual access token, and give it a name, a
+#     description, and an expiration date. Leave the IP ranges empty.
+#     Under Packages, choose Read and Write, then All packages. Don't mess
+#     with Organizations. Then click "Generate token" and save the token
+#     in GitHub's secrets as ``NPMJS_COM_TOKEN``.
+
+
+---
+
+name: 😌 Stable integration & delivery
+
+
+# Driving Event
+# -------------
+#
+# What event starts this workflow: a push of a release tag.
+#
+# For the "glob++" pattern syntax, see https://git.io/JJZQt
+
+on:
+    push:
+        tags:
+            - 'release/*'
+
+
+# What to Do
+# ----------
+#
+# Round up, yee-haw!
+
+jobs:
+    stable-assembly:
+        name: 🐴 Stable Assembly
+        runs-on: ubuntu-latest
+        steps:
+            -
+                name: 💳 Checkout
+                uses: actions/checkout@v2
+                with:
+                    lfs: true
+                    token: ${{secrets.ADMIN_GITHUB_TOKEN}}
+                    fetch-depth: 0
+            -
+                name: 🤠 Roundup
+                uses: NASA-PDS/roundup-action@stable
+                with:
+                    assembly: stable
+                env:
+                    ADMIN_GITHUB_TOKEN: ${{secrets.ADMIN_GITHUB_TOKEN}}
+                    NPMJS_COM_TOKEN: ${{secrets.NPMJS_COM_TOKEN}}
+
+...
+
+# -*- mode: yaml; indent: 4; fill-column: 120; coding: utf-8 -*-

--- a/.github/workflows/unstable-cicd.yaml
+++ b/.github/workflows/unstable-cicd.yaml
@@ -1,0 +1,73 @@
+# 🏃‍♀️ Continuous Integration and Delivery: Unstable
+# =================================================
+#
+# Note: for this workflow to succeed, the following secrets must be installed
+# in the repository (or inherited from the repository's organization):
+#
+# Note: for this workflow to succeed, the following secrets must be installed
+# in the repository:
+#
+# ``ADMIN_GITHUB_TOKEN``
+#     A personal access token of a user with collaborator or better access to
+#     the project repository.
+# ``NPMJS_COM_TOKEN`` — token for npmjs.com. To create such a token, visit
+#     npmjs.com, log in, and go to your profile menu → Access Tokens →
+#     Generate new token → Granual access token, and give it a name, a
+#     description, and an expiration date. Leave the IP ranges empty.
+#     Under Packages, choose Read and Write, then All packages. Don't mess
+#     with Organizations. Then click "Generate token" and save the token
+#     in GitHub's secrets as ``NPMJS_COM_TOKEN``.
+
+
+---
+
+name: 🤪 Unstable integration & delivery
+
+
+# Driving Event
+# -------------
+#
+# What event starts this workflow: a push to ``main``.
+#
+# parlance). For the "glob++" pattern syntax, see https://git.io/JJZQt
+
+on:
+    push:
+        branches:
+             - main
+        paths-ignore:
+            - 'CHANGELOG.md'
+            - 'docs/requirements/**'
+    workflow_dispatch:
+
+
+# What to Do
+# ----------
+#
+# Round up, yee-haw!
+
+jobs:
+    unstable-assembly:
+        name: 🧩 Unstable Assembly
+        if: github.actor != 'pdsen-ci'
+        runs-on: ubuntu-latest
+        steps:
+            -
+                name: 💳 Checkout
+                uses: actions/checkout@v2
+                with:
+                    lfs: true
+                    token: ${{secrets.ADMIN_GITHUB_TOKEN}}
+                    fetch-depth: 0
+            -
+                name: 🤠 Roundup
+                uses: NASA-PDS/roundup-action@stable
+                with:
+                    assembly: unstable
+                env:
+                    ADMIN_GITHUB_TOKEN: ${{secrets.ADMIN_GITHUB_TOKEN}}
+                    NPMJS_COM_TOKEN: ${{secrets.NPMJS_COM_TOKEN}}
+
+...
+
+# -*- mode: yaml; indent: 4; fill-column: 120; coding: utf-8 -*-


### PR DESCRIPTION
## 🗒️ Summary

Merge this to add Roundup-based continuous integration to the Node.js template repository.

## ⚙️ Test Data and/or Report

See the [sandbox's Node.js repository for past successes](https://github.com/nasa-pds-engineering-node/essence/actions).

Note that the three "Node.js Branch CI / build" checks (below) are orthogonal to this.

## ♻️ Related Issues

- [devops#73](https://github.com/NASA-PDS/devops/issues/73)
